### PR TITLE
fix(EventBus): Fix the issue that EventBus does not support multiple Publish

### DIFF
--- a/src/Dispatcher/Masa.Contrib.Dispatcher.Events/EventBus.cs
+++ b/src/Dispatcher/Masa.Contrib.Dispatcher.Events/EventBus.cs
@@ -68,6 +68,4 @@ public class EventBus : IEventBus
 
         await _unitOfWork.CommitAsync(cancellationToken);
     }
-
-    // public bool IsFirst() =>
 }

--- a/src/Dispatcher/Masa.Contrib.Dispatcher.Events/IInitializeServiceProvider.cs
+++ b/src/Dispatcher/Masa.Contrib.Dispatcher.Events/IInitializeServiceProvider.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Dispatcher.Events;
+
+/// <summary>
+/// Used to filter EventBus middleware that does not support recursion
+/// </summary>
+public interface IInitializeServiceProvider
+{
+    /// <summary>
+    /// Get the initialization state. If it has been initialized, the middleware that does not support recursion is no longer executed.
+    /// </summary>
+    bool IsInitialize { get; }
+
+    /// <summary>
+    /// service has been initialized
+    /// </summary>
+    void Initialize();
+
+    /// <summary>
+    /// reset initialization state
+    /// </summary>
+    void Reset();
+}

--- a/src/Dispatcher/Masa.Contrib.Dispatcher.Events/Internal/InitializeServiceProvider.cs
+++ b/src/Dispatcher/Masa.Contrib.Dispatcher.Events/Internal/InitializeServiceProvider.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Dispatcher.Events.Internal;
+
+internal class InitializeServiceProvider : IInitializeServiceProvider
+{
+    private bool _state;
+
+    public bool IsInitialize => _state;
+
+    public InitializeServiceProvider()
+    {
+        _state = false;
+    }
+
+    public void Initialize()
+    {
+        _state = true;
+    }
+
+    public void Reset()
+    {
+        _state = false;
+    }
+}

--- a/src/Dispatcher/Masa.Contrib.Dispatcher.Events/Internal/InitializeServiceProvider.cs
+++ b/src/Dispatcher/Masa.Contrib.Dispatcher.Events/Internal/InitializeServiceProvider.cs
@@ -5,22 +5,22 @@ namespace Masa.Contrib.Dispatcher.Events.Internal;
 
 internal class InitializeServiceProvider : IInitializeServiceProvider
 {
-    private bool _state;
+    private bool _initialized;
 
-    public bool IsInitialize => _state;
+    public bool IsInitialize => _initialized;
 
     public InitializeServiceProvider()
     {
-        _state = false;
+        _initialized = false;
     }
 
     public void Initialize()
     {
-        _state = true;
+        _initialized = true;
     }
 
     public void Reset()
     {
-        _state = false;
+        _initialized = false;
     }
 }

--- a/src/Dispatcher/Masa.Contrib.Dispatcher.Events/Internal/Middleware/TransactionMiddleware.cs
+++ b/src/Dispatcher/Masa.Contrib.Dispatcher.Events/Internal/Middleware/TransactionMiddleware.cs
@@ -6,12 +6,14 @@ namespace Masa.Contrib.Dispatcher.Events.Internal.Middleware;
 internal class TransactionMiddleware<TEvent> : Middleware<TEvent>
     where TEvent : IEvent
 {
+    private readonly IInitializeServiceProvider _initializeServiceProvider;
     private readonly IUnitOfWork? _unitOfWork;
 
     public override bool SupportRecursive => false;
 
-    public TransactionMiddleware(IUnitOfWork? unitOfWork = null)
+    public TransactionMiddleware(IInitializeServiceProvider initializeServiceProvider, IUnitOfWork? unitOfWork = null)
     {
+        _initializeServiceProvider = initializeServiceProvider;
         _unitOfWork = unitOfWork;
     }
 
@@ -35,6 +37,10 @@ internal class TransactionMiddleware<TEvent> : Middleware<TEvent>
             }
 
             throw;
+        }
+        finally
+        {
+            _initializeServiceProvider.Reset();
         }
     }
 }

--- a/src/Dispatcher/Masa.Contrib.Dispatcher.Events/README.md
+++ b/src/Dispatcher/Masa.Contrib.Dispatcher.Events/README.md
@@ -212,3 +212,7 @@ IEventBus is the core of the event bus. It can be used with Cqrs, Uow, Masa.Cont
 > Question 4. Why is exception retry enabled but not executed?
 
      > The default `UserFriendlyException` does not support retries, if you need to support retries, you need to reimplement `IStrategyExceptionProvider`
+
+> Question 5. Is EventBus thread safe?
+
+     > EventBus is not thread-safe. If multiple threads execute EventBus.PublishAsync() concurrently, exceptions such as data unsubmitted may occur

--- a/src/Dispatcher/Masa.Contrib.Dispatcher.Events/README.md
+++ b/src/Dispatcher/Masa.Contrib.Dispatcher.Events/README.md
@@ -211,7 +211,7 @@ IEventBus is the core of the event bus. It can be used with Cqrs, Uow, Masa.Cont
 
 > Question 4. Why is exception retry enabled but not executed?
 
-     > The default `UserFriendlyException` does not support retries, if you need to support retries, you need to reimplement `IStrategyExceptionProvider`
+     > The default `UserFriendlyException` does not support retries, if you need to support retries, you need to reimplement `IExceptionStrategyProvider`
 
 > Question 5. Is EventBus thread safe?
 

--- a/src/Dispatcher/Masa.Contrib.Dispatcher.Events/README.zh-CN.md
+++ b/src/Dispatcher/Masa.Contrib.Dispatcher.Events/README.zh-CN.md
@@ -211,3 +211,7 @@ IEventBus是事件总线的核心，配合Cqrs、Uow、Masa.Contrib.Ddd.Domain.R
 > 问题4. 为什么开启了异常重试却未执行重试？
 
     > 默认`UserFriendlyException`不支持重试，如果需要支持重试，则需要重新实现`IStrategyExceptionProvider`
+
+> 问题5. EventBus是线程安全的吗？
+
+    > EventBus不是线程安全的，如果多线程并发执行EventBus.PublishAsync()，则可能会出现数据未提交等异常

--- a/src/Dispatcher/Masa.Contrib.Dispatcher.Events/README.zh-CN.md
+++ b/src/Dispatcher/Masa.Contrib.Dispatcher.Events/README.zh-CN.md
@@ -210,7 +210,7 @@ IEventBus是事件总线的核心，配合Cqrs、Uow、Masa.Contrib.Ddd.Domain.R
 
 > 问题4. 为什么开启了异常重试却未执行重试？
 
-    > 默认`UserFriendlyException`不支持重试，如果需要支持重试，则需要重新实现`IStrategyExceptionProvider`
+    > 默认`UserFriendlyException`不支持重试，如果需要支持重试，则需要重新实现`IExceptionStrategyProvider`
 
 > 问题5. EventBus是线程安全的吗？
 

--- a/src/Dispatcher/Masa.Contrib.Dispatcher.Events/ServiceCollectionExtensions.cs
+++ b/src/Dispatcher/Masa.Contrib.Dispatcher.Events/ServiceCollectionExtensions.cs
@@ -37,6 +37,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(new Dispatcher(services, assemblies).Build(lifetime));
         services.TryAddSingleton<IExceptionStrategyProvider, DefaultExceptionStrategyProvider>();
         services.TryAdd(typeof(IExecutionStrategy), typeof(ExecutionStrategy), ServiceLifetime.Singleton);
+        services.TryAddScoped<IInitializeServiceProvider, InitializeServiceProvider>();
         services.AddTransient(typeof(IMiddleware<>), typeof(TransactionMiddleware<>));
         services.AddScoped(typeof(IEventBus), typeof(EventBus));
         return services;
@@ -62,6 +63,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(new Dispatcher(services, assemblies).Build(lifetime));
         services.TryAddSingleton<IExceptionStrategyProvider, DefaultExceptionStrategyProvider>();
         services.TryAdd(typeof(IExecutionStrategy), typeof(ExecutionStrategy), ServiceLifetime.Singleton);
+        services.TryAddScoped<IInitializeServiceProvider, InitializeServiceProvider>();
         services.AddTransient(typeof(IMiddleware<>), typeof(TransactionMiddleware<>));
         services.AddScoped(typeof(IEventBus), typeof(EventBus));
 

--- a/src/Dispatcher/Masa.Contrib.Dispatcher.Events/Strategies/ExecutionStrategy.cs
+++ b/src/Dispatcher/Masa.Contrib.Dispatcher.Events/Strategies/ExecutionStrategy.cs
@@ -5,12 +5,12 @@ namespace Masa.Contrib.Dispatcher.Events.Strategies;
 
 public class ExecutionStrategy : IExecutionStrategy
 {
-    private readonly IExceptionStrategyProvider _strategyExceptionProvider;
+    private readonly IExceptionStrategyProvider _exceptionStrategyProvider;
     private readonly ILogger<ExecutionStrategy>? _logger;
 
-    public ExecutionStrategy(IExceptionStrategyProvider strategyExceptionProvider, ILogger<ExecutionStrategy>? logger = null)
+    public ExecutionStrategy(IExceptionStrategyProvider exceptionStrategyProvider, ILogger<ExecutionStrategy>? logger = null)
     {
-        _strategyExceptionProvider = strategyExceptionProvider;
+        _exceptionStrategyProvider = exceptionStrategyProvider;
         _logger = logger;
     }
 
@@ -27,7 +27,7 @@ public class ExecutionStrategy : IExecutionStrategy
             {
                 if (retryTimes > 0)
                 {
-                    _strategyExceptionProvider.LogWrite(LogLevel.Warning,
+                    _exceptionStrategyProvider.LogWrite(LogLevel.Warning,
                         null,
                         "----- Error Publishing event {@Event} start: The {retries}th retrying consume a message failed. message id: {messageId} -----",
                         @event, retryTimes, @event.GetEventId());
@@ -39,20 +39,20 @@ public class ExecutionStrategy : IExecutionStrategy
             {
                 if (retryTimes > 0)
                 {
-                    _strategyExceptionProvider.LogWrite(LogLevel.Error,
+                    _exceptionStrategyProvider.LogWrite(LogLevel.Error,
                         ex,
                         "----- Error Publishing event {@Event} finish: The {retries}th retrying consume a message failed. message id: {messageId} -----",
                         @event, retryTimes, @event.GetEventId());
                 }
                 else
                 {
-                    _strategyExceptionProvider.LogWrite(LogLevel.Error,
+                    _exceptionStrategyProvider.LogWrite(LogLevel.Error,
                         ex,
                         "----- Error Publishing event {@Event}: after {maxRetries}th executions and we will stop retrying. message id: {messageId} -----",
                         @event, strategyOptions.MaxRetryCount, @event.GetEventId());
                 }
                 exception = ex;
-                if (_strategyExceptionProvider.SupportRetry(exception))
+                if (_exceptionStrategyProvider.SupportRetry(exception))
                 {
                     retryTimes++;
                 }

--- a/test/Masa.Contrib.Ddd.Domain.Entities.Tests/Events/RegisterUserEvent.cs
+++ b/test/Masa.Contrib.Ddd.Domain.Entities.Tests/Events/RegisterUserEvent.cs
@@ -8,4 +8,6 @@ public record RegisterUserEvent : DomainEvent
     public Guid Id { get; set; }
 
     public string Name { get; set; }
+
+    public bool IsSendDomainEvent { get; set; } = true;
 }

--- a/test/Masa.Contrib.Ddd.Domain.Entities.Tests/User.cs
+++ b/test/Masa.Contrib.Ddd.Domain.Entities.Tests/User.cs
@@ -14,15 +14,18 @@ public class User : AggregateRoot<Guid>
         Id = Guid.NewGuid();
     }
 
-    public User(Guid id, string name)
+    public User(Guid id, string name, bool isSendDomainEvent)
     {
         Id = id;
         Name = name;
-        this.AddDomainEvent(new RegisterUserDomainEvent()
+        if (isSendDomainEvent)
         {
-            Id = Id,
-            Name = name
-        });
+            this.AddDomainEvent(new RegisterUserDomainEvent()
+            {
+                Id = Id,
+                Name = name
+            });
+        }
     }
 
     public void UpdateName(string name)

--- a/test/Masa.Contrib.Ddd.Domain.Integrated.Tests/DomainEventTest.cs
+++ b/test/Masa.Contrib.Ddd.Domain.Integrated.Tests/DomainEventTest.cs
@@ -65,4 +65,56 @@ public class DomainEventTest
         Assert.IsNotNull(user);
         Assert.IsTrue(user.Name == "Tom2");
     }
+
+    [TestMethod]
+    public async Task TestPublishMultiCommandReturnDataIs2()
+    {
+        var dbContext = _serviceProvider.GetRequiredService<CustomizeDbContext>();
+        await dbContext.Database.EnsureCreatedAsync();
+        var eventBus = _serviceProvider.GetRequiredService<IEventBus>();
+
+        var @event = new RegisterUserEvent()
+        {
+            Id = Guid.NewGuid(),
+            Name = "Jim1",
+            IsSendDomainEvent = false
+        };
+        await eventBus.PublishAsync(@event);
+
+        @event = new RegisterUserEvent()
+        {
+            Id = Guid.NewGuid(),
+            Name = "Jim2",
+            IsSendDomainEvent = false
+        };
+        await eventBus.PublishAsync(@event);
+
+        Assert.IsTrue(dbContext.Set<User>().Count() == 2);
+    }
+
+    [TestMethod]
+    public async Task TestPublishMultiCommandReturnDataIs1()
+    {
+        var dbContext = _serviceProvider.GetRequiredService<CustomizeDbContext>();
+        await dbContext.Database.EnsureCreatedAsync();
+        var eventBus = _serviceProvider.GetRequiredService<IEventBus>();
+
+        var @event = new RegisterUserEvent()
+        {
+            Id = Guid.NewGuid(),
+            Name = "error",
+            IsSendDomainEvent = false
+        };
+        await Assert.ThrowsExceptionAsync<Exception>(async () => await eventBus.PublishAsync(@event), "custom exception");
+
+        @event = new RegisterUserEvent()
+        {
+            Id = Guid.NewGuid(),
+            Name = "Jim2",
+            IsSendDomainEvent = false
+        };
+        await eventBus.PublishAsync(@event);
+
+        Assert.IsTrue(dbContext.Set<User>().Count() == 1);
+    }
 }

--- a/test/Masa.Contrib.Ddd.Domain.Integrated.Tests/Handlers/UserHandler.cs
+++ b/test/Masa.Contrib.Ddd.Domain.Integrated.Tests/Handlers/UserHandler.cs
@@ -13,8 +13,13 @@ public class UserHandler
     [EventHandler]
     public async Task RegisterUser(RegisterUserEvent @event)
     {
-        var user = new User(@event.Id, @event.Name);
+        var user = new User(@event.Id, @event.Name,@event.IsSendDomainEvent);
         await _repository.AddAsync(user);
+
+        if (user.Name.Contains("error"))
+        {
+            throw new Exception("custom exception");// Throwing exceptions manually
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
# Description

1. Fixed that only the first data will be saved after calling EventBus.PublishAsync multiple times 
2. After repairing the data exception, if there are still transaction submissions in the future, the problem of data rollback error

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
